### PR TITLE
Add lombok as annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,19 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.38</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
-
 </project>


### PR DESCRIPTION
Fixes issues regarding spring not recognizing code generated by lombok.

If this does not fix the issue, try enabling annotation processing in IntelliJ.


![image](https://github.com/user-attachments/assets/8481e544-04db-4308-99cd-efe922c041d7)
