### PR TITLE
Fix spring.config.import line

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
-optional:spring.config.import=classpath:/datasource.properties
+spring.config.import=optional:classpath:datasource.properties
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 


### PR DESCRIPTION
As mentioned in #6 and #5, this fixes a syntax error that made it impossible to import `datasource.properties`.