### PR TITLE
Code style formatting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,44 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>io.spring.javaformat</groupId>
+				<artifactId>spring-javaformat-maven-plugin</artifactId>
+				<version>0.0.43</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.1.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>9.3</version>
+					</dependency>
+					<dependency>
+						<groupId>io.spring.javaformat</groupId>
+						<artifactId>spring-javaformat-checkstyle</artifactId>
+						<version>0.0.43</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>checkstyle-validation</id>
+						<phase>validate</phase>
+						<inherited>true</inherited>
+						<configuration>
+							<configLocation>io/spring/javaformat/checkstyle/checkstyle.xml</configLocation>
+							<includeTestSourceDirectory>true</includeTestSourceDirectory>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/p1g14/pomodoro_timer_api/PomodoroTimerApiApplication.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/PomodoroTimerApiApplication.java
@@ -3,10 +3,11 @@ package com.p1g14.pomodoro_timer_api;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-
 @SpringBootApplication
 public class PomodoroTimerApiApplication {
+
 	public static void main(String[] args) {
 		SpringApplication.run(PomodoroTimerApiApplication.class, args);
 	}
+
 }

--- a/src/test/java/com/p1g14/pomodoro_timer_api/DatabaseConnectionTest.java
+++ b/src/test/java/com/p1g14/pomodoro_timer_api/DatabaseConnectionTest.java
@@ -14,24 +14,25 @@ import java.sql.DatabaseMetaData;
 @SpringBootTest
 public class DatabaseConnectionTest {
 
-    @Autowired
-    private DataSource dataSource;
+	@Autowired
+	private DataSource dataSource;
 
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
 
-    @Test
-    public void testDatabaseConnection() throws Exception {
-        try (Connection connection = dataSource.getConnection()) {
-            DatabaseMetaData metaData = connection.getMetaData();
+	@Test
+	public void testDatabaseConnection() throws Exception {
+		try (Connection connection = dataSource.getConnection()) {
+			DatabaseMetaData metaData = connection.getMetaData();
 
-            System.out.println("Connected to: " + metaData.getURL());
-            System.out.println("DB User: " + metaData.getUserName());
-            System.out.println("DB Product: " + metaData.getDatabaseProductName());
-            System.out.println("DB Version: " + metaData.getDatabaseProductVersion());
-        }
+			System.out.println("Connected to: " + metaData.getURL());
+			System.out.println("DB User: " + metaData.getUserName());
+			System.out.println("DB Product: " + metaData.getDatabaseProductName());
+			System.out.println("DB Version: " + metaData.getDatabaseProductVersion());
+		}
 
-        Integer result = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
-        System.out.println("Simple Query Test: SELECT 1 -> " + result);
-    }
+		Integer result = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+		System.out.println("Simple Query Test: SELECT 1 -> " + result);
+	}
+
 }


### PR DESCRIPTION
Add ability to enforce Spring Framework Code Style.

This adds support for formatting using [spring-javaformat](https://github.com/spring-io/spring-javaformat) and linting using checkstyle.
This enables us to have a consistent code style through the entire codebase and makes the process of testing code style trivial.

To make formatting and linting work, each developer needs to edit their `~/.m2/settings.xml` file by adding
```xml
<pluginGroups>
	<pluginGroup>io.spring.javaformat</pluginGroup>
</pluginGroups>
```

If you do not have this file, create it and paste this:
```xml
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
  <pluginGroups>
	<pluginGroup>io.spring.javaformat</pluginGroup>
  </pluginGroups>
</settings>
```
([source](https://maven.apache.org/settings.html))

To format the code run:
```bash
./mvnw spring-javaformat:apply
```

To validate the code run:
```bash
./mvnw spring-javaformat:validate
```

Currently, the checkstyle plugin is set to run automatically when building and to fail the build if there are code style errors. However, this should probably be changed in the future by adding a workflow for linting and softening the restrictions when building locally.