### PR TITLE
Storage of jwt secret key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ build/
 
 .env
 datasource.properties
+jwt-secrets.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,9 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
-optional:spring.config.import=classpath:/datasource.properties
+jwt.secret=${JWT_SECRET}
+
+spring.config.import=optional:classpath:datasource.properties,optional:classpath:jwt-secrets.properties
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 


### PR DESCRIPTION
Add a new file named `jwt-secrets.properties` that stores the jwt secret key.

Similar to #1 we need a file to store secrets related to Json Web Tokens. 

For local development, we import the `jwt-secrets.properties` file into the `application.properties` and overwrite the `jwt.secret` field. In the server, the file will be missing and instead we set the `jwt.secret` field using environment variables.
This is used during authentication to decode tokens and to issue new tokens. 

One consideration is to combine this with `datasource.properties` to reduce the amount of files a developer has to create locally.