### PR TITLE
API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Add support for automatic API documentation through the use of swagger (OpenAPI).

While running, the documentation can be accessed through `/swagger-ui.html` or `/swagger-ui/index.html`

You should get something that looks like this:
![image](https://github.com/user-attachments/assets/eef508df-00fa-44d6-bcc9-ae7b404ef03d)

This change is to easily see which endpoints are available, what data they need, and what they send back.