### PR TITLE
Gather all development properties in a single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build/
 .env
 datasource.properties
 jwt-secrets.properties
+development.properties

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 
 jwt.secret=${JWT_SECRET}
-spring.config.import=optional:classpath:datasource.properties,optional:classpath:jwt-secrets.properties
+spring.config.import=optional:classpath:development.properties
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # Hibernate settings


### PR DESCRIPTION
This changes the paradigm of creating separate files for configuring different aspects of the application into creating a single file for all local config.

This fixes #17. Instead of creating `datasource.properties` and `jwt-secrets.properties` we now create a single file `development.properties`.
To avoid accidentally committing the old files, these were kept in the `.gitignore` file.
This simplifies the process of building locally and is more scalable in the future.

The new way should also be documented in the `CONTRIBUTING.md` file currently being reviewed in #11.