### PR TITLE
Global exception handling

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
@@ -38,7 +38,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(Map.of("error", ex.getMessage()));
+                .body(Map.of("error", "Access denied"));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.p1g14.pomodoro_timer_api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Map<String, String>> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "Invalid email or password"));
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleUserNotFound(UsernameNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "Invalid email or password"));
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleResourceNotFound(ResourceNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", "Resource not found"));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+    }
+
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidJson(HttpMessageNotReadableException ex) {
+        return ResponseEntity.badRequest().body(Map.of("error", "Invalid request format"));
+    }
+
+    // Fallback handler for unexpected errors
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneralException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "Something went wrong"));
+    }
+}

--- a/src/main/java/com/p1g14/pomodoro_timer_api/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.p1g14.pomodoro_timer_api.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Add global exception handling for meaningful error messages.

This change introduces a new class `GlobalExceptionHandler` that catches errors raised by the controller and gives a standardized response based on the exception. Not only does this allow us to separate the handling of exceptions from the controller but it will allow us to throw exceptions in different layers of the application and still have them be caught by the global exception handler without any inbetween layers having to handle them.

This also allows us to give more meaningful error messages back to the client. in the future we could also create custom exceptions that we can pass relevant data for even more detailed error messages.