### PR TITLE
Configure connection limit and lifetime

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,4 +14,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 
-
+# Hikari settings
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.idle-timeout=600000
+spring.datasource.hikari.max-lifetime=1800000
+spring.datasource.hikari.connection-timeout=30000


### PR DESCRIPTION
Set a limit on max connections and configure the lifetime of connections.

This fixes #32. 
Adding configuration solves the issue of hikari eating up all available connections, freeing up space for local development.
All the actual values are only preliminary and are up for potentially being tweaked later.