### PR TITLE
DTO Validation and Error Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ build/
 datasource.properties
 jwt-secrets.properties
 development.properties
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
@@ -3,6 +3,7 @@ package com.p1g14.pomodoro_timer_api.auth;
 import com.p1g14.pomodoro_timer_api.auth.dto.LoginRequest;
 import com.p1g14.pomodoro_timer_api.auth.dto.AuthResponse;
 import com.p1g14.pomodoro_timer_api.auth.dto.RegisterRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,14 +14,14 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-
+//Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
     @PostMapping("/register")
-    public ResponseEntity<AuthResponse> register(@RequestBody RegisterRequest request) {
+    public ResponseEntity<AuthResponse> register(@RequestBody @Valid RegisterRequest request) {
         return ResponseEntity.ok(authService.register(request));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));
     }
 

--- a/src/main/java/com/p1g14/pomodoro_timer_api/auth/dto/LoginRequest.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/auth/dto/LoginRequest.java
@@ -1,9 +1,14 @@
 package com.p1g14.pomodoro_timer_api.auth.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class LoginRequest {
+    @NotBlank(message = "Email can not be blank")
+    @Email(message = "Not a valid email adress")
     private String email;
+    @NotBlank(message = "Password can not be blank")
     private String password;
 }

--- a/src/main/java/com/p1g14/pomodoro_timer_api/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/auth/dto/RegisterRequest.java
@@ -1,9 +1,15 @@
 package com.p1g14.pomodoro_timer_api.auth.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class RegisterRequest {
+    @NotBlank
+    @Email(message = "Must be a valid email")
     private String email;
+    @NotBlank @Size(min = 8, message = "Password must be at least 8 characters")
     private String password;
 }

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
@@ -25,7 +25,7 @@ public class TimerController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody TimerUpdateRequest dto) {
+    public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody @Valid TimerUpdateRequest dto) {
         return ResponseEntity.ok(timerService.updateTimer(id, dto));
     }
     //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
@@ -3,6 +3,7 @@ package com.p1g14.pomodoro_timer_api.timer;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerCreateRequest;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerDetailsResponse;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerUpdateRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,12 +28,12 @@ public class TimerController {
     public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody TimerUpdateRequest dto) {
         return ResponseEntity.ok(timerService.updateTimer(id, dto));
     }
-
+    //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
     @PostMapping
-    public ResponseEntity<TimerDetailsResponse> createTimer(@RequestBody TimerCreateRequest dto) {
+    public ResponseEntity<TimerDetailsResponse> createTimer(@RequestBody @Valid TimerCreateRequest dto) {
         TimerDetailsResponse createdTimer = timerService.createTimer(dto);
-        URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdTimer.getId()).toUri();
-        return ResponseEntity.created(uri).build();
+        URI url = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdTimer.getId()).toUri();
+        return ResponseEntity.created(url).build();
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerCreateRequest.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerCreateRequest.java
@@ -1,5 +1,8 @@
 package com.p1g14.pomodoro_timer_api.timer.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,8 +13,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TimerCreateRequest {
+    @NotBlank(message = "Name must not be empty")
     private String name;
+    @NotNull
+    @Min(value = 5, message = "Work duration must be at least 5 minute")
     private Integer workDuration;
+    @NotNull @Min(value = 1, message = "Break duration must be at least 1 minute")
     private Integer breakDuration;
+    @NotNull @Min(value = 1, message = "Pomodoro count must be at least 1")
     private Integer pomodoroCount;
 }

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerUpdateRequest.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.p1g14.pomodoro_timer_api.timer.dto;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,10 +15,17 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TimerUpdateRequest {
+    @NotNull
     private Long id;
+    @NotBlank
     private String name;
+    @NotNull
     private LocalDateTime createdAt;
+    @NotNull
+    @Min(value = 5, message = "Work duration must be at least 5 minute")
     private Integer workDuration;
+    @NotNull @Min(value = 1, message = "Break duration must be at least 1 minute")
     private Integer breakDuration;
+    @NotNull @Min(value = 1, message = "Pomodoro count must be at least 1")
     private Integer pomodoroCount;
 }


### PR DESCRIPTION
- added  DTO validations

- added a @ExceptionHandler(MethodArgumentNotValidException.class) to GlobalExceptionHandler. When a @Valid @RequestBody DTO fails, Spring throws a MethodArgumentNotValidException. Our handler catches that and returns:

{
  "timestamp": "2025-05-04T01:32:10",
  "status": 400,
  "errors": {
    "name": "Name must not be blank",
    "workDuration": "Work duration must be at least 5 minute"
  }
}
`

- Errors is a Map from field names to human-readable messages, where we can add more than one error for a single request, shown JSON response is just an example, it could be different for each scenario (login, timer request, register etc.). Frontend should not be worry about the validation, they simply need to handle situations depending on status code and error message, if available.


Why return field-level messages?
This structured payload lets any client  precisely associate each error with the offending input field. A similar approach could also be used in other exceptions handling, simply by creating a ErrorResponse class where we specify what each error message will include, and in which structure. So that we would know exactly what we get in frontend when validation fails, and proceed accordingly without any inconsistency with response from backend for different validation errors. But this is another PR's issue.

