### PR TITLE
Add documentation for error codes and short operation description

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
@@ -3,6 +3,9 @@ package com.p1g14.pomodoro_timer_api.auth;
 import com.p1g14.pomodoro_timer_api.auth.dto.LoginRequest;
 import com.p1g14.pomodoro_timer_api.auth.dto.AuthResponse;
 import com.p1g14.pomodoro_timer_api.auth.dto.RegisterRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +17,28 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-//Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
+
+    //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
+
+    @Operation(summary = "Register a new user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request succeeded. The response contains the requested data."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "404", description = "The requested resource could not be found. It may not exist or the path is incorrect."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@RequestBody @Valid RegisterRequest request) {
         return ResponseEntity.ok(authService.register(request));
     }
 
+    @Operation(summary = "Login")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request succeeded. The response contains the requested data."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "404", description = "The requested resource could not be found. It may not exist or the path is incorrect."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.ok(authService.login(request));

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
@@ -3,8 +3,12 @@ package com.p1g14.pomodoro_timer_api.timer;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerCreateRequest;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerDetailsResponse;
 import com.p1g14.pomodoro_timer_api.timer.dto.TimerUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -19,16 +23,42 @@ public class TimerController {
 
     private final TimerService timerService;
 
+    @Operation(summary = "Get a timer by ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request succeeded. The response contains the requested data."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "401", description = "Authentication failed or missing. A valid token or credentials are required."),
+            @ApiResponse(responseCode = "403", description = "You are authenticated, but not authorized to perform this action."),
+            @ApiResponse(responseCode = "404", description = "The requested resource could not be found. It may not exist or the path is incorrect."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @GetMapping("/{id}")
     public ResponseEntity<TimerDetailsResponse> getTimerById(@PathVariable Long id) {
         return ResponseEntity.ok(timerService.getTimerById(id));
     }
 
+    @Operation(summary = "Update timer of ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Request succeeded. The response contains the requested data."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "401", description = "Authentication failed or missing. A valid token or credentials are required."),
+            @ApiResponse(responseCode = "403", description = "You are authenticated, but not authorized to perform this action."),
+            @ApiResponse(responseCode = "404", description = "The requested resource could not be found. It may not exist or the path is incorrect."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @PutMapping("/{id}")
     public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody @Valid TimerUpdateRequest dto) {
         return ResponseEntity.ok(timerService.updateTimer(id, dto));
     }
+
     //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
+    @Operation(summary = "Create a new timer")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Resource successfully created. A new resource has been added as a result of the request."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "401", description = "Authentication failed or missing. A valid token or credentials are required."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @PostMapping
     public ResponseEntity<TimerDetailsResponse> createTimer(@RequestBody @Valid TimerCreateRequest dto) {
         TimerDetailsResponse createdTimer = timerService.createTimer(dto);
@@ -36,6 +66,16 @@ public class TimerController {
         return ResponseEntity.created(url).build();
     }
 
+
+    @Operation(summary = "Delete timer of ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Request succeeded, but there's no content to return in the response body."),
+            @ApiResponse(responseCode = "400", description = "The request is invalid or malformed. Check input parameters or data format."),
+            @ApiResponse(responseCode = "401", description = "Authentication failed or missing. A valid token or credentials are required."),
+            @ApiResponse(responseCode = "403", description = "You are authenticated, but not authorized to perform this action."),
+            @ApiResponse(responseCode = "404", description = "The requested resource could not be found. It may not exist or the path is incorrect."),
+            @ApiResponse(responseCode = "500", description = "An unexpected error occurred on the server. Please try again later.")
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteTimer(@PathVariable Long id) {
         timerService.deleteTimer(id);


### PR DESCRIPTION
Add documentation of what status codes can be returned from the API.

This enables front end developers to easily see what status codes are returned by the API so they can handle each one appropriately.

Right now this is placed on each method separately, which results in a lot of repetition. In the future we should look for another way to handle this.