### PR TITLE
Hotfix: Log unexpected errors

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/exception/GlobalExceptionHandler.java
@@ -58,6 +58,7 @@ public class GlobalExceptionHandler {
     // Fallback handler for unexpected errors
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleGeneralException(Exception ex) {
+        ex.printStackTrace();
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(Map.of("error", "Something went wrong"));


### PR DESCRIPTION
Added `ex.printStackTrace()` to `GlobalExceptionHandler.handleGeneralException(...)` to get information about unexpected errors.
