### PR TITLE
Remove createdAt field in `TimerUpdateRequest`

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerUpdateRequest.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/dto/TimerUpdateRequest.java
@@ -20,8 +20,6 @@ public class TimerUpdateRequest {
     @NotBlank
     private String name;
     @NotNull
-    private LocalDateTime createdAt;
-    @NotNull
     @Min(value = 5, message = "Work duration must be at least 5 minute")
     private Integer workDuration;
     @NotNull @Min(value = 1, message = "Break duration must be at least 1 minute")


### PR DESCRIPTION
This was supposed to fix #44 but there seems to be no problem. The DTO maps properly and the entity is updated.

Removed `createdAt` field in `TimerUpdateRequest` since this field should not be able to change.