### PR TITLE
Remove "/api" from auth controller root path

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/auth/AuthController.java
@@ -9,12 +9,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
-//Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
+
+    //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
     @PostMapping("/register")
     public ResponseEntity<AuthResponse> register(@RequestBody @Valid RegisterRequest request) {
         return ResponseEntity.ok(authService.register(request));


### PR DESCRIPTION
Fixes #43. I landed on that each controller should have its own sub-path. However, having "/api" is redundant and possibly confusing. So it was removed.