### PR TITLE
Make naming of request arguments into "request"

### DIFF
--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerController.java
@@ -30,13 +30,13 @@ public class TimerController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody @Valid TimerUpdateRequest dto) {
-        return ResponseEntity.ok(timerService.updateTimer(id, dto));
+    public ResponseEntity<TimerDetailsResponse> updateTimer(@PathVariable Long id, @RequestBody @Valid TimerUpdateRequest request) {
+        return ResponseEntity.ok(timerService.updateTimer(id, request));
     }
     //Spring will automatically trigger bean‐validation when we annotate the @RequestBody parameter with @Valid
     @PostMapping
-    public ResponseEntity<TimerDetailsResponse> createTimer(@RequestBody @Valid TimerCreateRequest dto) {
-        TimerDetailsResponse createdTimer = timerService.createTimer(dto);
+    public ResponseEntity<TimerDetailsResponse> createTimer(@RequestBody @Valid TimerCreateRequest request) {
+        TimerDetailsResponse createdTimer = timerService.createTimer(request);
         URI url = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdTimer.getId()).toUri();
         return ResponseEntity.created(url).build();
     }

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerMapper.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerMapper.java
@@ -13,20 +13,20 @@ public class TimerMapper {
 
     private final ModelMapper modelMapper;
 
-    public Timer fromTimerCreateRequest(TimerCreateRequest timerCreateRequest) {
-        return modelMapper.map(timerCreateRequest, Timer.class);
+    public Timer fromTimerCreateRequest(TimerCreateRequest request) {
+        return modelMapper.map(request, Timer.class);
     }
 
     public TimerDetailsResponse toTimerDetailsResponse(Timer timer) {
         return modelMapper.map(timer, TimerDetailsResponse.class);
     }
 
-    public Timer fromTimerUpdateRequest(TimerUpdateRequest timerUpdateRequest, Timer timer) {
-        return modelMapper.map(timerUpdateRequest, Timer.class);
+    public Timer fromTimerUpdateRequest(TimerUpdateRequest request, Timer timer) {
+        return modelMapper.map(request, Timer.class);
     }
 
-    public Timer updateTimerEntity(TimerUpdateRequest timerUpdateRequest, Timer timer) {
-        modelMapper.map(timerUpdateRequest, timer);
+    public Timer updateTimerEntity(TimerUpdateRequest request, Timer timer) {
+        modelMapper.map(request, timer);
         return timer;
     }
 }

--- a/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerService.java
+++ b/src/main/java/com/p1g14/pomodoro_timer_api/timer/TimerService.java
@@ -39,19 +39,19 @@ public class TimerService {
         return timerMapper.toTimerDetailsResponse(timer);
     }
 
-    public TimerDetailsResponse updateTimer(Long id, TimerUpdateRequest timerUpdateRequest) {
+    public TimerDetailsResponse updateTimer(Long id, TimerUpdateRequest request) {
         User user = getCurrentUser();
         Timer timer = getTimerValidated(id, user);
 
-        timer = timerMapper.updateTimerEntity(timerUpdateRequest, timer);
+        timer = timerMapper.updateTimerEntity(request, timer);
         Timer updatedTimer = timerRepository.save(timer);
         return timerMapper.toTimerDetailsResponse(updatedTimer);
     }
 
-    public TimerDetailsResponse createTimer(TimerCreateRequest timerCreateRequest) {
+    public TimerDetailsResponse createTimer(TimerCreateRequest request) {
         User user = getCurrentUser();
 
-        Timer timer = timerMapper.fromTimerCreateRequest(timerCreateRequest);
+        Timer timer = timerMapper.fromTimerCreateRequest(request);
         timer.setUser(user);
         timer.setCreatedAt(LocalDateTime.now());
 


### PR DESCRIPTION
Fixes #58. Make all request DTO method arguments be called "request".
This makes the semantics more consistent and the code more readable.